### PR TITLE
Build offline-ready clicker counter PWA with printable tape

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Clicker Counter Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,52 @@
-# Simple-counter-
-A simple counter app
+# Clicker Counter PWA
+
+An offline-ready clicker counter with a printable tape workflow. Built with vanilla HTML, CSS, and JavaScript—no build step required.
+
+## Features
+
+- Increment, decrement, reset, and adjustable step values with long-press auto-repeat and keyboard shortcuts.
+- Description-based sequencing that tracks separate counts for each label.
+- "Print to Tape" workflow that logs timestamped entries and automatically advances sequences.
+- Persistent tape log with export/print view optimized for PDF and hard-copy records.
+- Optional haptics and audio feedback, plus theme and compact layout toggles.
+- Full offline support via service worker precaching for GitHub Pages hosting.
+
+## Getting Started
+
+1. Clone the repository:
+
+   ```bash
+   git clone https://github.com/your-username/clicker-counter-pwa.git
+   cd clicker-counter-pwa
+   ```
+
+2. Serve the site locally (any static file server works). For example with Python:
+
+   ```bash
+   python -m http.server 8000
+   ```
+
+3. Visit `http://localhost:8000` in your browser to use the app.
+
+## Keyboard Shortcuts
+
+| Action | Keys |
+| --- | --- |
+| Increment | `Space`, `Enter`, `+`, `=`, `ArrowUp`, `ArrowRight` |
+| Decrement | `-`, `ArrowDown`, `ArrowLeft` |
+| Reset | `0`, `R` |
+| Print to tape | `Shift` + `P` |
+
+## Deploying to GitHub Pages
+
+1. Commit and push the repository to GitHub.
+2. In the repository settings, open **Pages**.
+3. Under **Source**, choose **Deploy from a branch**.
+4. Select the `main` branch and the `/ (root)` folder, then save.
+5. After Pages builds, the PWA will be live at `https://<your-username>.github.io/clicker-counter-pwa/`.
+
+The service worker is configured for the root path. If you publish to a subdirectory, adjust the cached paths inside `sw.js` accordingly.
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/app.js
+++ b/app.js
@@ -1,0 +1,405 @@
+const STORAGE_KEY = 'clicker-state';
+const defaultState = {
+  count: 0,
+  step: 1,
+  label: '',
+  seqEnabled: true,
+  seqByLabel: {},
+  tape: [],
+  toggles: {
+    sound: false,
+    haptics: false,
+    theme: 'system',
+    compact: false
+  }
+};
+
+const elements = {
+  count: document.getElementById('count'),
+  increment: document.getElementById('increment'),
+  decrement: document.getElementById('decrement'),
+  reset: document.getElementById('reset'),
+  step: document.getElementById('step'),
+  label: document.getElementById('label'),
+  seqEnabled: document.getElementById('seqEnabled'),
+  sequenceDisplay: document.getElementById('sequenceDisplay'),
+  resetSequence: document.getElementById('resetSequence'),
+  printTape: document.getElementById('printTape'),
+  shareCount: document.getElementById('shareCount'),
+  exportTape: document.getElementById('exportTape'),
+  clearTape: document.getElementById('clearTape'),
+  tapeList: document.getElementById('tapeList'),
+  tapeTemplate: document.getElementById('tapeItemTemplate'),
+  soundToggle: document.getElementById('soundToggle'),
+  hapticsToggle: document.getElementById('hapticsToggle'),
+  themeToggle: document.getElementById('themeToggle'),
+  compactToggle: document.getElementById('compactToggle'),
+  announcer: document.getElementById('announcer')
+};
+
+let state = loadState();
+let audioContext;
+
+function loadState() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return deepClone(defaultState);
+    const parsed = JSON.parse(stored);
+    return {
+      ...deepClone(defaultState),
+      ...parsed,
+      seqByLabel: { ...defaultState.seqByLabel, ...(parsed.seqByLabel || {}) },
+      tape: Array.isArray(parsed.tape) ? parsed.tape : [],
+      toggles: { ...defaultState.toggles, ...(parsed.toggles || {}) }
+    };
+  } catch (error) {
+    console.error('Failed to load state', error);
+    return deepClone(defaultState);
+  }
+}
+
+function saveState() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  } catch (error) {
+    console.error('Failed to save state', error);
+  }
+}
+
+function deepClone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+function getLabelKey(label = state.label) {
+  return (label || '').trim().toLowerCase() || '__default__';
+}
+
+function getNextSequence() {
+  const key = getLabelKey();
+  if (!state.seqByLabel[key]) {
+    state.seqByLabel[key] = 1;
+  }
+  return state.seqByLabel[key];
+}
+
+function updateSequenceDisplay() {
+  if (!state.seqEnabled) {
+    elements.sequenceDisplay.textContent = 'Sequence off';
+    elements.sequenceDisplay.setAttribute('aria-label', 'Sequence disabled for this description');
+    return;
+  }
+  const seq = getNextSequence();
+  elements.sequenceDisplay.textContent = `Sequence #${seq}`;
+  elements.sequenceDisplay.removeAttribute('aria-label');
+}
+
+function updateCountDisplay() {
+  elements.count.textContent = state.count;
+}
+
+function updateTapeList() {
+  const list = elements.tapeList;
+  list.innerHTML = '';
+  if (!state.tape.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'Tape is empty. Use "Print to Tape" to add entries.';
+    empty.className = 'help';
+    empty.setAttribute('role', 'status');
+    list.appendChild(empty);
+    return;
+  }
+  state.tape.forEach(entry => {
+    const clone = elements.tapeTemplate.content.firstElementChild.cloneNode(true);
+    clone.dataset.id = entry.id;
+    const timeEl = clone.querySelector('.tape-time');
+    const labelEl = clone.querySelector('.tape-label');
+    const seqEl = clone.querySelector('.tape-seq');
+    const countEl = clone.querySelector('.tape-count');
+    const date = new Date(entry.ts);
+    timeEl.textContent = date.toLocaleString();
+    timeEl.dateTime = entry.ts;
+    labelEl.textContent = entry.label || '—';
+    seqEl.textContent = entry.seq != null ? `Seq ${entry.seq}` : '—';
+    countEl.textContent = entry.count;
+    list.appendChild(clone);
+  });
+}
+
+function applyToggles() {
+  elements.soundToggle.checked = state.toggles.sound;
+  elements.hapticsToggle.checked = state.toggles.haptics;
+  elements.themeToggle.value = state.toggles.theme;
+  elements.compactToggle.checked = state.toggles.compact;
+  applyTheme(state.toggles.theme);
+  document.body.classList.toggle('compact', Boolean(state.toggles.compact));
+}
+
+function applyTheme(theme) {
+  const html = document.documentElement;
+  if (theme === 'system') {
+    html.setAttribute('data-theme', window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  } else {
+    html.setAttribute('data-theme', theme);
+  }
+}
+
+function setCount(value) {
+  state.count = value;
+  updateCountDisplay();
+  saveState();
+}
+
+function changeCount(delta) {
+  const newValue = state.count + delta;
+  setCount(newValue);
+  feedback();
+}
+
+function resetCount() {
+  setCount(0);
+  feedback();
+  announce('Counter reset');
+}
+
+function feedback() {
+  if (state.toggles.haptics && 'vibrate' in navigator) {
+    navigator.vibrate(15);
+  }
+  if (state.toggles.sound) {
+    playSound();
+  }
+}
+
+function playSound() {
+  try {
+    if (!audioContext) {
+      audioContext = new (window.AudioContext || window.webkitAudioContext)();
+    }
+    if (audioContext.state === 'suspended') {
+      audioContext.resume();
+    }
+    const duration = 0.08;
+    const oscillator = audioContext.createOscillator();
+    const gain = audioContext.createGain();
+    oscillator.type = 'triangle';
+    oscillator.frequency.value = 880;
+    gain.gain.value = 0.001;
+    gain.gain.exponentialRampToValueAtTime(0.1, audioContext.currentTime + 0.01);
+    gain.gain.exponentialRampToValueAtTime(0.0001, audioContext.currentTime + duration);
+    oscillator.connect(gain).connect(audioContext.destination);
+    oscillator.start();
+    oscillator.stop(audioContext.currentTime + duration);
+  } catch (error) {
+    console.warn('Unable to play sound', error);
+  }
+}
+
+function announce(message) {
+  if (!elements.announcer) return;
+  elements.announcer.textContent = '';
+  requestAnimationFrame(() => {
+    elements.announcer.textContent = message;
+  });
+}
+
+function getStep() {
+  const step = Math.max(1, Number(elements.step.value) || 1);
+  elements.step.value = step;
+  state.step = step;
+  saveState();
+  return step;
+}
+
+function handlePrintToTape() {
+  const entry = {
+    id: crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`,
+    ts: new Date().toISOString(),
+    label: state.label.trim(),
+    seq: state.seqEnabled ? getNextSequence() : null,
+    count: state.count
+  };
+  state.tape = [entry, ...state.tape];
+  if (state.seqEnabled) {
+    const key = getLabelKey();
+    state.seqByLabel[key] = entry.seq + 1;
+  }
+  setCount(0);
+  announce('Entry added to tape');
+  updateSequenceDisplay();
+  updateTapeList();
+  saveState();
+}
+
+function handleClearTape() {
+  if (!state.tape.length) return;
+  if (confirm('Clear all tape entries? This cannot be undone.')) {
+    state.tape = [];
+    saveState();
+    updateTapeList();
+    announce('Tape cleared');
+  }
+}
+
+function handleExportTape() {
+  window.open('print.html?auto=1', '_blank', 'noopener');
+}
+
+function handleShareCount() {
+  const description = state.label.trim() || 'Untitled item';
+  const text = `${description}: ${state.count}`;
+  const title = 'Clicker Counter';
+  if (navigator.share) {
+    navigator.share({ title, text }).catch(() => {});
+  } else if (navigator.clipboard && navigator.clipboard.writeText) {
+    navigator.clipboard.writeText(text).then(() => announce('Count copied to clipboard')).catch(() => announce('Unable to copy'));
+  } else {
+    prompt('Copy this count', text);
+  }
+}
+
+function handleDescriptionChange() {
+  state.label = elements.label.value;
+  saveState();
+  updateSequenceDisplay();
+}
+
+function handleSeqToggle() {
+  state.seqEnabled = elements.seqEnabled.checked;
+  saveState();
+  updateSequenceDisplay();
+}
+
+function handleResetSequence() {
+  const key = getLabelKey();
+  state.seqByLabel[key] = 1;
+  saveState();
+  updateSequenceDisplay();
+  announce('Sequence reset for current description');
+}
+
+function attachRepeater(button, delta) {
+  let timeoutId;
+  let intervalId;
+  const stepAction = () => changeCount(delta * getStep());
+
+  const start = event => {
+    event.preventDefault();
+    stepAction();
+    timeoutId = window.setTimeout(() => {
+      intervalId = window.setInterval(stepAction, 90);
+    }, 350);
+  };
+
+  const stop = () => {
+    clearTimeout(timeoutId);
+    clearInterval(intervalId);
+  };
+
+  button.addEventListener('pointerdown', start);
+  button.addEventListener('pointerleave', stop);
+  window.addEventListener('pointerup', stop);
+}
+
+function bindEvents() {
+  elements.increment.addEventListener('click', () => changeCount(getStep()));
+  elements.decrement.addEventListener('click', () => changeCount(-getStep()));
+  elements.reset.addEventListener('click', resetCount);
+  elements.step.addEventListener('change', getStep);
+  elements.label.addEventListener('input', handleDescriptionChange);
+  elements.seqEnabled.addEventListener('change', handleSeqToggle);
+  elements.resetSequence.addEventListener('click', handleResetSequence);
+  elements.printTape.addEventListener('click', handlePrintToTape);
+  elements.shareCount.addEventListener('click', handleShareCount);
+  elements.exportTape.addEventListener('click', handleExportTape);
+  elements.clearTape.addEventListener('click', handleClearTape);
+
+  elements.soundToggle.addEventListener('change', () => {
+    state.toggles.sound = elements.soundToggle.checked;
+    saveState();
+  });
+
+  elements.hapticsToggle.addEventListener('change', () => {
+    state.toggles.haptics = elements.hapticsToggle.checked;
+    saveState();
+  });
+
+  elements.themeToggle.addEventListener('change', () => {
+    state.toggles.theme = elements.themeToggle.value;
+    applyTheme(state.toggles.theme);
+    saveState();
+  });
+
+  elements.compactToggle.addEventListener('change', () => {
+    state.toggles.compact = elements.compactToggle.checked;
+    document.body.classList.toggle('compact', state.toggles.compact);
+    saveState();
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement || event.target instanceof HTMLSelectElement) {
+      return;
+    }
+    switch (event.key) {
+      case 'ArrowUp':
+      case 'ArrowRight':
+      case '+':
+      case '=':
+      case 'Enter':
+      case ' ': {
+        event.preventDefault();
+        changeCount(getStep());
+        break;
+      }
+      case 'ArrowDown':
+      case 'ArrowLeft':
+      case '-': {
+        event.preventDefault();
+        changeCount(-getStep());
+        break;
+      }
+      case '0':
+      case 'r':
+      case 'R': {
+        event.preventDefault();
+        resetCount();
+        break;
+      }
+      case 'p':
+      case 'P': {
+        if (event.shiftKey) {
+          event.preventDefault();
+          handlePrintToTape();
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  });
+
+  attachRepeater(elements.increment, 1);
+  attachRepeater(elements.decrement, -1);
+}
+
+function init() {
+  elements.step.value = state.step;
+  elements.label.value = state.label;
+  elements.seqEnabled.checked = state.seqEnabled;
+  applyToggles();
+  updateSequenceDisplay();
+  updateCountDisplay();
+  updateTapeList();
+  bindEvents();
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (state.toggles.theme === 'system') {
+      applyTheme('system');
+    }
+  });
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('./sw.js').catch(err => console.error('Service worker registration failed', err));
+    });
+  }
+}
+
+init();

--- a/icons/icon-192.svg
+++ b/icons/icon-192.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d47a1" />
+      <stop offset="100%" stop-color="#42a5f5" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="120" height="120" rx="24" fill="url(#g)" stroke="#bbdefb" stroke-width="6" />
+  <rect x="58" y="28" width="12" height="72" rx="6" fill="#e3f2fd" />
+  <rect x="34" y="58" width="60" height="12" rx="6" fill="#e3f2fd" />
+  <rect x="28" y="92" width="72" height="12" rx="6" fill="#bbdefb" opacity="0.8" />
+</svg>

--- a/icons/icon-512.svg
+++ b/icons/icon-512.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0d47a1" />
+      <stop offset="100%" stop-color="#42a5f5" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="120" height="120" rx="24" fill="url(#g)" stroke="#bbdefb" stroke-width="6" />
+  <rect x="58" y="28" width="12" height="72" rx="6" fill="#e3f2fd" />
+  <rect x="34" y="58" width="60" height="12" rx="6" fill="#e3f2fd" />
+  <rect x="28" y="92" width="72" height="12" rx="6" fill="#bbdefb" opacity="0.8" />
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="system">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#0d47a1">
+  <title>Clicker Counter PWA</title>
+  <link rel="manifest" href="manifest.webmanifest">
+  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="print.css" media="print">
+</head>
+<body>
+  <header class="app-header">
+    <h1>Clicker Counter</h1>
+    <p class="tagline">Track counts, build printable tapes, stay offline-ready.</p>
+  </header>
+  <main>
+    <section class="panel" aria-labelledby="context-heading">
+      <div class="section-header">
+        <h2 id="context-heading">Counting context</h2>
+      </div>
+      <label class="field">
+        <span>Description</span>
+        <input type="text" id="label" name="label" placeholder="e.g., Truck — Concrete" autocomplete="off" aria-describedby="sequence-info">
+      </label>
+      <div class="toggle-row">
+        <label class="switch">
+          <input type="checkbox" id="seqEnabled" checked>
+          <span class="switch-label">Sequence this item</span>
+        </label>
+        <output id="sequenceDisplay" role="status" aria-live="polite">Sequence #1</output>
+        <button type="button" id="resetSequence" class="secondary">Reset Sequence</button>
+      </div>
+      <p id="sequence-info" class="help">Each description has its own running sequence. Printing to tape records the current count and advances the sequence.</p>
+    </section>
+
+    <section class="panel" aria-labelledby="counter-heading">
+      <div class="section-header">
+        <h2 id="counter-heading">Counter</h2>
+      </div>
+      <output id="count" role="status" aria-live="polite" aria-atomic="true">0</output>
+      <div class="controls">
+        <button type="button" id="decrement" class="control" aria-label="Decrement">−</button>
+        <button type="button" id="increment" class="control" aria-label="Increment">+</button>
+      </div>
+      <div class="controls">
+        <button type="button" id="reset" class="secondary">Reset</button>
+        <label class="field step-field">
+          <span>Step</span>
+          <input type="number" id="step" min="1" value="1">
+        </label>
+      </div>
+      <div class="toggle-grid">
+        <label class="switch">
+          <input type="checkbox" id="soundToggle">
+          <span class="switch-label">Sound</span>
+        </label>
+        <label class="switch">
+          <input type="checkbox" id="hapticsToggle">
+          <span class="switch-label">Haptics</span>
+        </label>
+        <label class="select">
+          <span>Theme</span>
+          <select id="themeToggle">
+            <option value="system">System</option>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+        <label class="switch">
+          <input type="checkbox" id="compactToggle">
+          <span class="switch-label">Compact layout</span>
+        </label>
+      </div>
+      <div class="action-row">
+        <button type="button" id="printTape" class="primary">Print to Tape</button>
+        <button type="button" id="shareCount" class="secondary">Share / Export Count</button>
+      </div>
+    </section>
+
+    <section class="panel" aria-labelledby="tape-heading">
+      <div class="section-header">
+        <h2 id="tape-heading">Tape log</h2>
+        <div class="section-actions">
+          <button type="button" id="exportTape" class="secondary">Export / Print Tape</button>
+          <button type="button" id="clearTape" class="danger">Clear Tape</button>
+        </div>
+      </div>
+      <p class="help">Tape entries capture the timestamp, description, sequence, and count. Clearing the tape removes all entries.</p>
+      <ul id="tapeList" aria-live="polite" aria-label="Tape entries"></ul>
+      <template id="tapeItemTemplate">
+        <li class="tape-item">
+          <span class="tape-time"></span>
+          <div class="tape-body">
+            <span class="tape-label"></span>
+            <span class="tape-seq"></span>
+          </div>
+          <span class="tape-count"></span>
+        </li>
+      </template>
+    </section>
+  </main>
+  <div id="announcer" class="sr-only" aria-live="polite"></div>
+  <footer class="app-footer">
+    <p>Built for offline use. Install to keep the counter on hand anywhere.</p>
+  </footer>
+  <script type="module" src="app.js"></script>
+</body>
+</html>

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "Clicker Counter PWA",
+  "short_name": "Counter",
+  "description": "Offline-ready clicker counter with tape logging",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#0d47a1",
+  "theme_color": "#0d47a1",
+  "icons": [
+    {
+      "src": "icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/print.css
+++ b/print.css
@@ -1,0 +1,128 @@
+@media screen {
+  body.print-page {
+    font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+    margin: 0;
+    background: #f8f9fb;
+    color: #102027;
+    padding: clamp(1rem, 3vw, 2.5rem);
+  }
+
+  body.print-page main {
+    max-width: 720px;
+    margin: 0 auto;
+  }
+
+  body.print-page h1 {
+    margin-bottom: 0.25rem;
+  }
+
+  body.print-page ul {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  body.print-page li {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 0.5rem;
+    background: white;
+    padding: 0.65rem 0.85rem;
+    border-radius: 0.75rem;
+    box-shadow: 0 0.4rem 1.2rem -0.9rem rgba(0,0,0,0.4);
+  }
+
+  body.print-page .print-time {
+    font-feature-settings: "tnum" 1;
+    color: #546e7a;
+  }
+
+  body.print-page .print-label {
+    font-weight: 600;
+  }
+
+  body.print-page .print-seq {
+    color: #1e88e5;
+  }
+
+  body.print-page .print-count {
+    font-weight: 700;
+    font-size: 1.35rem;
+  }
+}
+
+@media print {
+  :root {
+    color-scheme: light;
+  }
+
+  body.print-page {
+    font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+    margin: 0;
+    padding: 1.2cm;
+    background: #fff;
+    color: #000;
+  }
+
+  header {
+    text-align: center;
+    margin-bottom: 0.5cm;
+  }
+
+  header h1 {
+    margin: 0;
+    font-size: 16pt;
+  }
+
+  header p {
+    margin: 0.2cm 0 0;
+    font-size: 10pt;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  li {
+    display: grid;
+    grid-template-columns: 3.5cm 1fr 2cm;
+    gap: 0.3cm;
+    padding: 0.3cm 0;
+    border-bottom: 1px solid rgba(0,0,0,0.2);
+    break-inside: avoid;
+  }
+
+  li:last-child {
+    border-bottom: none;
+  }
+
+  .print-time {
+    font-size: 10pt;
+    color: #333;
+  }
+
+  .print-label {
+    font-weight: 600;
+    font-size: 12pt;
+  }
+
+  .print-seq {
+    font-size: 10pt;
+    color: #000;
+  }
+
+  .print-count {
+    font-size: 14pt;
+    font-weight: 700;
+    text-align: right;
+  }
+
+  @page {
+    margin: 1.2cm;
+  }
+}

--- a/print.html
+++ b/print.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Printable Tape</title>
+  <link rel="stylesheet" href="print.css">
+  <meta name="robots" content="noindex">
+</head>
+<body class="print-page">
+  <main>
+    <header>
+      <h1>Counter Tape</h1>
+      <p id="generated"></p>
+    </header>
+    <section>
+      <ul id="printTapeList"></ul>
+    </section>
+  </main>
+  <template id="printTapeItem">
+    <li>
+      <time class="print-time"></time>
+      <div class="print-body">
+        <span class="print-label"></span>
+        <span class="print-seq"></span>
+      </div>
+      <span class="print-count"></span>
+    </li>
+  </template>
+  <script>
+    (function() {
+      let tape = [];
+      try {
+        const parsed = JSON.parse(localStorage.getItem('clicker-state') || '{}');
+        tape = Array.isArray(parsed.tape) ? parsed.tape : [];
+      } catch (error) {
+        console.error('Unable to read stored tape', error);
+      }
+      const list = document.getElementById('printTapeList');
+      const template = document.getElementById('printTapeItem');
+      const generated = document.getElementById('generated');
+      generated.textContent = tape.length ? `Generated ${new Date().toLocaleString()}` : 'No tape entries stored yet.';
+      tape.forEach(entry => {
+        const clone = template.content.firstElementChild.cloneNode(true);
+        const timeEl = clone.querySelector('.print-time');
+        const labelEl = clone.querySelector('.print-label');
+        const seqEl = clone.querySelector('.print-seq');
+        const countEl = clone.querySelector('.print-count');
+        timeEl.dateTime = entry.ts;
+        timeEl.textContent = new Date(entry.ts).toLocaleString();
+        labelEl.textContent = entry.label || '—';
+        seqEl.textContent = entry.seq != null ? `Seq ${entry.seq}` : '—';
+        countEl.textContent = entry.count;
+        list.appendChild(clone);
+      });
+      if (new URLSearchParams(location.search).get('auto') === '1' && tape.length) {
+        window.addEventListener('load', () => setTimeout(() => window.print(), 100));
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,325 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fb;
+  --fg: #102027;
+  --accent: #0d47a1;
+  --accent-contrast: #ffffff;
+  --panel: #ffffff;
+  --panel-border: rgba(16,32,39,0.08);
+  --danger: #b71c1c;
+  --muted: #546e7a;
+  --focus: #ffb300;
+  font-size: 16px;
+}
+
+[data-theme="dark"] {
+  --bg: #101418;
+  --fg: #e0f2ff;
+  --panel: #161c23;
+  --panel-border: rgba(224,242,255,0.08);
+  --muted: #90a4ae;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: max(1rem, env(safe-area-inset-top)) max(1rem, env(safe-area-inset-right)) max(2rem, env(safe-area-inset-bottom)) max(1rem, env(safe-area-inset-left));
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+body.compact {
+  font-size: 15px;
+}
+
+.app-header,
+.app-footer {
+  text-align: center;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 3vw + 1rem, 3rem);
+}
+
+.tagline {
+  color: var(--muted);
+  margin: 0.25rem 0 0;
+}
+
+main {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  box-shadow: 0 1rem 2rem -1.5rem rgba(0,0,0,0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.section-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.95rem;
+}
+
+.field input,
+.select select {
+  font: inherit;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--panel-border);
+  background: color-mix(in srgb, var(--panel) 90%, var(--fg) 10%);
+  color: var(--fg);
+  min-height: 3rem;
+}
+
+.field input:focus,
+.select select:focus,
+button:focus-visible {
+  outline: 3px solid var(--focus);
+  outline-offset: 2px;
+}
+
+.toggle-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.switch input {
+  width: 2.75rem;
+  height: 1.5rem;
+  appearance: none;
+  background: var(--panel-border);
+  border-radius: 0.75rem;
+  position: relative;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.switch input::after {
+  content: "";
+  position: absolute;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  background: var(--panel);
+  top: 0.125rem;
+  left: 0.125rem;
+  transition: transform 0.2s ease;
+}
+
+.switch input:checked {
+  background: var(--accent);
+}
+
+.switch input:checked::after {
+  transform: translateX(1.25rem);
+}
+
+.switch-label {
+  font-weight: 600;
+}
+
+.select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.control {
+  flex: 1;
+  font-size: 2.5rem;
+  padding: 0.75rem;
+  min-height: 4.5rem;
+  border-radius: 1rem;
+  border: none;
+  background: var(--accent);
+  color: var(--accent-contrast);
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+
+.control:active {
+  transform: scale(0.97);
+}
+
+#count {
+  font-size: clamp(3rem, 6vw + 1rem, 5.5rem);
+  text-align: center;
+  font-weight: 700;
+}
+
+button {
+  font: inherit;
+  border-radius: 0.75rem;
+  border: none;
+  cursor: pointer;
+  padding: 0.75rem 1rem;
+  min-height: 3rem;
+  background: var(--panel-border);
+  color: var(--fg);
+}
+
+button.primary {
+  background: var(--accent);
+  color: var(--accent-contrast);
+}
+
+button.secondary {
+  background: color-mix(in srgb, var(--panel) 85%, var(--accent) 15%);
+}
+
+button.danger {
+  background: var(--danger);
+  color: #fff;
+}
+
+button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.toggle-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.step-field {
+  width: 7rem;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.help {
+  color: var(--muted);
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+#tapeList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: min(50vh, 380px);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.tape-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--panel) 80%, var(--accent) 20%);
+  color: var(--accent-contrast);
+}
+
+.tape-item .tape-time {
+  font-feature-settings: "tnum" 1;
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.tape-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.tape-label {
+  font-weight: 600;
+}
+
+.tape-seq {
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.tape-count {
+  font-size: 1.5rem;
+  font-weight: 700;
+}
+
+.app-footer {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001s !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001s !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,47 @@
+const CACHE_VERSION = 'counter-pwa-v1';
+const BASE = self.location.pathname.replace(/sw\.js$/, '');
+const APP_SHELL = [
+  './',
+  './index.html',
+  './styles.css',
+  './print.css',
+  './print.html',
+  './app.js',
+  './manifest.webmanifest',
+  './icons/icon-192.svg',
+  './icons/icon-512.svg'
+].map(path => new URL(path, self.location.origin + BASE).pathname);
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_VERSION).then(cache => cache.addAll(APP_SHELL)).then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(key => key !== CACHE_VERSION).map(key => caches.delete(key))))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  if (request.method !== 'GET') {
+    return;
+  }
+  const fallbackUrl = new URL('./index.html', self.location.origin + BASE).pathname;
+  event.respondWith(
+    caches.match(request).then(cached => {
+      const networkFetch = fetch(request).then(response => {
+        const clone = response.clone();
+        caches.open(CACHE_VERSION).then(cache => cache.put(request, clone));
+        return response;
+      }).catch(() => cached || caches.match(fallbackUrl));
+      if (cached) {
+        return cached;
+      }
+      return networkFetch;
+    }).catch(() => caches.match(fallbackUrl))
+  );
+});


### PR DESCRIPTION
## Summary
- replace the simple counter with a full-featured, theme-aware clicker interface backed by persistent state
- add tape sequencing workflow with printable export page and sharing helpers
- wire up PWA assets including manifest, service worker, and icons for offline-ready GitHub Pages hosting

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68e3d6600978832b85d7e103f0338624