### PR TITLE
Add job context, daily tape, and CSV reporting features

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,13 @@ An offline-ready clicker counter with a printable tape workflow. Built with vani
 ## Features
 
 - Reliable increment, decrement, and reset controls with long-press auto-repeat that avoids double-counting and supports arrow key shortcuts.
-- Description-based sequencing that tracks separate counts for each label.
+- Description-based sequencing that tracks separate counts for each label, with per-label title modes (simple numbers, hidden, or custom prefixes).
+- Job context field stored with every tape entry for downstream grouping.
 - "Print to Tape" workflow that logs timestamped entries and automatically advances sequences.
+- Daily tape that preserves every Print-to-Tape event for the current calendar day.
+- One-click daily CSV export combining the main and daily tapes, with an optional post-export day reset.
 - Persistent tape log with export/print view optimized for PDF and hard-copy records.
+- Dedicated "Clear Day / Reset All" action to clear the counter, tapes, and sequences without touching global preferences.
 - Optional haptics and audio feedback, plus theme and compact layout toggles.
 - Full offline support via service worker precaching for GitHub Pages hosting.
 - Print preview with a dedicated Close button for returning to the main counter.

--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
         <h2 id="context-heading">Counting context</h2>
       </div>
       <label class="field">
+        <span>Job</span>
+        <input type="text" id="job" name="job" placeholder="e.g., Pour A" autocomplete="off">
+      </label>
+      <label class="field">
         <span>Description</span>
         <input type="text" id="label" name="label" placeholder="e.g., Truck — Concrete" autocomplete="off" aria-describedby="sequence-info">
       </label>
@@ -31,7 +35,21 @@
         <output id="sequenceDisplay" role="status" aria-live="polite">Sequence #1</output>
         <button type="button" id="resetSequence" class="secondary">Reset Sequence</button>
       </div>
-      <p id="sequence-info" class="help">Each description has its own running sequence. Printing to tape records the current count and advances the sequence.</p>
+      <div class="sequence-options" aria-live="polite">
+        <label class="select">
+          <span>Sequence title</span>
+          <select id="seqTitleMode">
+            <option value="simple">Simple (#1)</option>
+            <option value="custom">Custom prefix</option>
+            <option value="none">None</option>
+          </select>
+        </label>
+        <label class="field" id="seqTitleCustomField">
+          <span>Custom prefix</span>
+          <input type="text" id="seqTitleCustom" name="seqTitleCustom" placeholder="e.g., Truck" autocomplete="off">
+        </label>
+      </div>
+      <p id="sequence-info" class="help">Each description has its own running sequence. Printing to tape records the current count, advances the sequence, and applies the selected title style.</p>
     </section>
 
     <section class="panel" aria-labelledby="counter-heading">
@@ -83,6 +101,7 @@
         <h2 id="tape-heading">Tape log</h2>
         <div class="section-actions">
           <button type="button" id="exportTape" class="secondary">Export / Print Tape</button>
+          <button type="button" id="exportDailyCsv" class="secondary">Print Daily Report (CSV)</button>
           <button type="button" id="clearTape" class="danger">Clear Tape</button>
         </div>
       </div>
@@ -93,13 +112,22 @@
           <span class="tape-time"></span>
           <div class="tape-body">
             <span class="tape-label"></span>
+            <span class="tape-job"></span>
             <span class="tape-seq"></span>
           </div>
           <span class="tape-count"></span>
         </li>
       </template>
+      <details id="dailyTapeDetails">
+        <summary>Daily tape (all Print-to-Tape entries today)</summary>
+        <p class="help">Daily tape keeps every Print-to-Tape event for the calendar day, even if you clear the main tape.</p>
+        <ul id="dailyTapeList" aria-live="polite" aria-label="Daily tape entries"></ul>
+      </details>
     </section>
   </main>
+  <div class="page-actions">
+    <button type="button" id="clearDay" class="danger wide">Clear Day / Reset All</button>
+  </div>
   <div id="announcer" class="sr-only" aria-live="polite"></div>
   <footer class="app-footer">
     <p>Built for offline use. Install to keep the counter on hand anywhere.</p>

--- a/print.css
+++ b/print.css
@@ -78,6 +78,11 @@
     font-weight: 600;
   }
 
+  body.print-page .print-job {
+    font-size: 0.85rem;
+    color: #607d8b;
+  }
+
   body.print-page .print-seq {
     color: #1e88e5;
   }
@@ -143,6 +148,11 @@
   .print-label {
     font-weight: 600;
     font-size: 12pt;
+  }
+
+  .print-job {
+    font-size: 10pt;
+    color: #444;
   }
 
   .print-seq {

--- a/print.html
+++ b/print.html
@@ -25,6 +25,7 @@
       <time class="print-time"></time>
       <div class="print-body">
         <span class="print-label"></span>
+        <span class="print-job"></span>
         <span class="print-seq"></span>
       </div>
       <span class="print-count"></span>
@@ -32,12 +33,20 @@
   </template>
   <script>
     (function() {
+      const STORAGE_KEYS = ['cc:v3', 'clicker-state'];
       let tape = [];
-      try {
-        const parsed = JSON.parse(localStorage.getItem('clicker-state') || '{}');
-        tape = Array.isArray(parsed.tape) ? parsed.tape : [];
-      } catch (error) {
-        console.error('Unable to read stored tape', error);
+      for (const key of STORAGE_KEYS) {
+        const stored = localStorage.getItem(key);
+        if (!stored) continue;
+        try {
+          const parsed = JSON.parse(stored);
+          tape = normalizeTapeEntries(parsed && parsed.tape);
+          if (tape.length || key === 'cc:v3') {
+            break;
+          }
+        } catch (error) {
+          console.error('Unable to parse stored tape', error);
+        }
       }
       const list = document.getElementById('printTapeList');
       const template = document.getElementById('printTapeItem');
@@ -48,12 +57,21 @@
         const clone = template.content.firstElementChild.cloneNode(true);
         const timeEl = clone.querySelector('.print-time');
         const labelEl = clone.querySelector('.print-label');
+        const jobEl = clone.querySelector('.print-job');
         const seqEl = clone.querySelector('.print-seq');
         const countEl = clone.querySelector('.print-count');
-        timeEl.dateTime = entry.ts;
-        timeEl.textContent = new Date(entry.ts).toLocaleString();
+        const date = new Date(entry.ts);
+        timeEl.dateTime = date.toISOString();
+        timeEl.textContent = date.toLocaleString();
         labelEl.textContent = entry.label || '—';
-        seqEl.textContent = entry.seq != null ? `Seq ${entry.seq}` : '—';
+        if (jobEl) {
+          jobEl.textContent = entry.job || '';
+          jobEl.hidden = !entry.job;
+        }
+        if (seqEl) {
+          seqEl.textContent = entry.seqText || '';
+          seqEl.hidden = !entry.seqText;
+        }
         countEl.textContent = entry.count;
         list.appendChild(clone);
       });
@@ -68,6 +86,46 @@
             window.location.href = './';
           }
         });
+      }
+
+      function normalizeTapeEntries(raw) {
+        if (!Array.isArray(raw)) return [];
+        return raw.map(entry => {
+          if (!entry || typeof entry !== 'object') return null;
+          const tsNumber = Number(entry.ts);
+          let ts = Number.isFinite(tsNumber) ? tsNumber : Date.parse(entry.ts);
+          if (!Number.isFinite(ts)) {
+            ts = Date.now();
+          }
+          const seqValue = entry.seq == null ? null : Number(entry.seq);
+          const seq = Number.isFinite(seqValue) ? Math.floor(seqValue) : null;
+          let seqMode = typeof entry.seqMode === 'string' ? entry.seqMode : (seq != null ? 'simple' : 'none');
+          if (!['none', 'simple', 'custom'].includes(seqMode)) {
+            seqMode = seq != null ? 'simple' : 'none';
+          }
+          let seqText = typeof entry.seqText === 'string' ? entry.seqText : '';
+          if (seq != null && !seqText) {
+            if (seqMode === 'custom' && typeof entry.seqTitleCustom === 'string' && entry.seqTitleCustom.trim()) {
+              seqText = `${entry.seqTitleCustom.trim()} #${seq}`;
+            } else {
+              seqText = `#${seq}`;
+            }
+          }
+          if (seq == null) {
+            seqMode = 'none';
+            seqText = '';
+          }
+          return {
+            id: typeof entry.id === 'string' ? entry.id : `${ts}-${Math.random().toString(16).slice(2)}`,
+            ts,
+            label: typeof entry.label === 'string' ? entry.label : '',
+            job: typeof entry.job === 'string' ? entry.job : '',
+            seq,
+            seqMode,
+            seqText,
+            count: Number(entry.count) || 0
+          };
+        }).filter(Boolean);
       }
     })();
   </script>

--- a/styles.css
+++ b/styles.css
@@ -99,6 +99,7 @@ main {
 .section-actions {
   display: flex;
   gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .field {
@@ -131,6 +132,13 @@ button:focus-visible {
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
+}
+
+.sequence-options {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
 }
 
 .switch {
@@ -300,6 +308,11 @@ button:disabled {
   font-weight: 600;
 }
 
+.tape-job {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
 .tape-seq {
   font-size: 0.85rem;
   opacity: 0.85;
@@ -313,6 +326,37 @@ button:disabled {
 .app-footer {
   font-size: 0.9rem;
   color: var(--muted);
+}
+
+#dailyTapeDetails {
+  margin-top: 1rem;
+}
+
+#dailyTapeDetails summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+#dailyTapeList {
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: min(50vh, 380px);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.page-actions {
+  display: flex;
+  justify-content: center;
+  padding: 0 0 1rem;
+}
+
+.page-actions .wide {
+  width: min(420px, 100%);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'cc-cache-v3';
+const CACHE_VERSION = 'cc-cache-v4';
 const BASE = self.location.pathname.replace(/sw\.js$/, '');
 const APP_SHELL = [
   './',


### PR DESCRIPTION
## Summary
- migrate the counter state to v3 with job tracking, customizable sequence titles, and a persistent daily tape plus CSV export workflow
- extend the UI with a job field, sequence title controls, daily tape viewer, CSV button, and a clear day/reset all action
- surface job and sequence text in the print view, refresh styling/documentation, and bump the service worker cache to v4

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e424618fec832b87e05bdc88638ca0